### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,26 @@ First, clone the repository to your local machine:
 ```bash
 git clone https://github.com/RiajulKashem/SRMS.git
 ```
+Now enter the directory:  
 
+```bash
+cd SRMS
+```
+Now create a virtual machine:  
+```bash
+virtualenv venv  
+source venv/bin/activate
+```
 Install the requirements:
 
 ```bash
-pip install -r requirements.txt
+pip install -r requirments.txt
 ```
 
 Apply the migrations:
 
 ```bash
+python manage.py makemigrations
 python manage.py migrate
 ```
 


### PR DESCRIPTION
The original description does not work. It does not mention to create a virtual environment and the pip install command is wrong as well. These changes have fixed it. Now it seems to work fine.  

It is important to create a virtual environment for Django projects especially when you are working with other projects and don't want to screw them up. 